### PR TITLE
Use background color rather than hardcoded black color to fill margin

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -88,6 +88,7 @@ static void do_clear_margins(struct screen *scr)
 {
 	unsigned int w, h, sw, sh;
 	struct uterm_mode *mode;
+	struct tsm_screen_attr attr;
 	int dw, dh;
 
 	mode = uterm_display_get_current(scr->disp);
@@ -101,12 +102,14 @@ static void do_clear_margins(struct screen *scr)
 	dw = sw - w;
 	dh = sh - h;
 
+	tsm_vte_get_def_attr(scr->term->vte, &attr);
+
 	if (dw > 0)
-		uterm_display_fill(scr->disp, 0, 0, 0,
+		uterm_display_fill(scr->disp, attr.br, attr.bg, attr.bb,
 				   w, 0,
 				   dw, h);
 	if (dh > 0)
-		uterm_display_fill(scr->disp, 0, 0, 0,
+		uterm_display_fill(scr->disp, attr.br, attr.bg, attr.bb,
 				   0, h,
 				   sw, dh);
 }

--- a/src/uterm_drm3d_render.c
+++ b/src/uterm_drm3d_render.c
@@ -498,6 +498,14 @@ int uterm_drm3d_display_fill(struct uterm_display *disp,
 	if (tmp > sh)
 		height = sh - y;
 
+	/* Caution:
+	 * opengl uses a coordinate system with the origin at _lower-left_ corner
+	 * and positive y-axis up, while other parts uses a coordinate system
+	 * with the origin at _upper-left_ corner and positive y-axis down.
+	 */
+	y = sh - y; // invert y-axis
+	y -= height; // move origin to lower left corner
+
 	glViewport(x, y, width, height);
 	glDisable(GL_BLEND);
 


### PR DESCRIPTION
Also fix a bug related to coordinate that preventing margin color to be correctly drawn:

opengl uses a coordinate system with the origin at **lower-left** corner and positive y-axis **up**, while other parts uses a coordinate system with the origin at **upper-left** corner and positive y-axis **down**.
