### PR TITLE
build: fix some compile errors

### DIFF
--- a/src/pty.c
+++ b/src/pty.c
@@ -299,7 +299,7 @@ static void setup_child(int master, struct winsize *ws)
 	if (ret)
 		log_warn("cannot reset blocked signals: %m");
 
-	for (i = 1; i < SIGUNUSED; ++i)
+	for (i = 1; i < SIGSYS; ++i)
 		signal(i, SIG_DFL);
 
 	ret = grantpt(master);

--- a/src/uterm_vt.c
+++ b/src/uterm_vt.c
@@ -50,6 +50,7 @@
 #include "shl_misc.h"
 #include "uterm_input.h"
 #include "uterm_vt.h"
+#include <sys/sysmacros.h>
 
 #define LOG_SUBSYSTEM "vt"
 


### PR DESCRIPTION
src/pty.c:

SIGUNUSED -> SIGSYS

The SIGUNUSED define (31) has been removed as part of glibc 2.26, which is used in Fedora 27 and Ubuntu 17.10.
https://bugs.swift.org/browse/SR-6409

src/uterm_vt.c:

Add sys/sysmacros.h

minor was defined in sys/sysmacros.h. So i add the header file uterm_vt.c.